### PR TITLE
在庫登録機能 #10

### DIFF
--- a/app/channels/item_channel.rb
+++ b/app/channels/item_channel.rb
@@ -1,0 +1,9 @@
+class ItemChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "item_channel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,29 @@
 class ItemsController < ApplicationController
   def index
     @shop = Shop.find(params['shop_id'])
-    @items = @shop.items
+  end
+
+  def new
+    @shop = Shop.find(params['shop_id'])
+    @item = Item.new
+  end
+
+  def create
+    @shop = Shop.find(params['shop_id'])
+    @item = Item.new(item_params)
+    if @item.save
+      item_id = Item.order(id: "DESC").limit(1).ids[0] #今投稿したitemのid取得
+      items_length = @shop.items.length #データ数０か１以上で場合分けするため
+      ActionCable.server.broadcast 'item_channel', content: {item: @item, item_id: item_id ,items_length: items_length}
+    end
+  end
+
+  private
+  def item_params
+    params.require(:item).permit(:name, :count).merge(shop_id: params[:shop_id])
+  end
+
+  def set_item
+    @shop = Shop.find(params['shop_id'])
   end
 end

--- a/app/javascript/channels/item_channel.js
+++ b/app/javascript/channels/item_channel.js
@@ -1,0 +1,52 @@
+import consumer from "./consumer";
+
+consumer.subscriptions.create("ItemChannel", {
+  connected() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received(data) {
+    // debugger;
+    // 要素取得
+    const items = document.getElementById("items");
+    const items_table = document.getElementById("items_table");
+    const items_empty = document.getElementById("items_empty");
+    // 追加する要素の素材を作成
+    const tr = document.createElement("tr");
+    const td_name = document.createElement("td");
+    const td_count = document.createElement("td");
+    const td_Button = document.createElement("td");
+    // createElementに商品名、在庫数を代入
+    td_name.textContent = data.content.item.name;
+    td_count.textContent = data.content.item.count;
+    const column = items.appendChild(tr); //itemsにtrを追加
+    column.appendChild(td_name); //追加したtrにtd_countを追加
+    column.appendChild(td_count); //追加したtrにtd_countを追加
+    // 以下ボタンの作成
+    td_Button.className = "w-25"; //td_Buttonにクラスを追加
+    const Button = column.appendChild(td_Button); //追加したtrにクラスを付与したtd_Buttonを追加
+    const addButton = document.createElement("a"); //aタグを作成
+    addButton.className = "btn btn-danger"; //addButtonにクラスを追加
+    addButton.textContent = "在庫を削除する"; //addButtonに要素を追加
+    addButton.href = `/shops/${data.content.item.shop_id}/items/${data.content.item_id}`; //addButtonにhrefを追加
+    // アイコン作成
+    const addButtonIcon = document.createElement("i");
+    addButtonIcon.className = "far fa-trash-alt mx-1";
+    Button.appendChild(addButton).appendChild(addButtonIcon);
+    if (data.content.items_length == 0) {
+      items_table.hidden = true;
+      items_empty.hidden = false;
+    } else {
+      // itemの時、テーブルがhidddenであるため表示させる
+      items_table.hidden = false;
+      // 追加された時に「商品はまだありません。」を消す
+      items_empty.hidden = true;
+    }
+    // 以下入力欄を空に
+    item_name.value = "";
+  },
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,11 +3,10 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-require("@rails/ujs").start()
-require("turbolinks").start()
-require("@rails/activestorage").start()
-require("channels")
-
+require("@rails/ujs").start();
+// require("turbolinks").start()
+require("@rails/activestorage").start();
+require("channels");
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,13 +1,12 @@
 <% if item.count == 0 %>
   <tr>
-    <th scope="row"><%= item_counter + 1 %></th>
     <td  class="text-muted"><del><%= item.name %></del></td>
     <td  class="text-muted"><%= item.count %></td>
-  </tr>
 <% else %>
   <tr>
-    <th scope="row"><%= item_counter + 1 %></th>
     <td><%= item.name %></td>
     <td><%= item.count %></td>
-  </tr>
 <% end %>
+    <td class="w-25"><%= link_to  shop_item_path(@shop,item), method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class: "btn btn-danger" do%>
+    在庫を削除する<i class="far fa-trash-alt mx-1"></i><% end %></td>
+  </tr>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,5 +1,13 @@
-<tr>
-  <th scope="row"><%= item_counter + 1 %></th>
-  <td><%= item.name %></td>
-  <td><%= item.count %></td>
-</tr>
+<% if item.count == 0 %>
+  <tr>
+    <th scope="row"><%= item_counter + 1 %></th>
+    <td  class="text-muted"><del><%= item.name %></del></td>
+    <td  class="text-muted"><%= item.count %></td>
+  </tr>
+<% else %>
+  <tr>
+    <th scope="row"><%= item_counter + 1 %></th>
+    <td><%= item.name %></td>
+    <td><%= item.count %></td>
+  </tr>
+<% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,9 +3,11 @@
   <div class="nav">
     <ul class="lists-left">
     <li><%= link_to  edit_shop_path(@shop), class: "btn btn-success m-3" do%>
-    店舗を編集する<i class="fa fa-edit mx-1"></i><% end %></li>
+    店舗情報を編集する<i class="fa fa-edit mx-1"></i><% end %></li>
+    <li><%= link_to  "#", class: "btn btn-success m-3" do%>
+    在庫を編集する<i class="fas fa-th mx-1"></i><% end %></li>
     <li><%= link_to  shop_path(@shop), method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class: "btn btn-danger m-3" do%>
-    店舗を削除する<i class="fa fa-edit mx-1"></i><% end %></li>
+    店舗を削除する<i class="far fa-trash-alt mx-1"></i><% end %></li>
     <li><%= link_to  shops_path, class: "btn btn-secondary m-3" do%>
     店舗一覧に戻る<i class="fa fa-edit mx-1"></i><% end %></li>
     </ul>
@@ -55,18 +57,22 @@
       </tbody>
     </table>
     <p class="font-weight-bold h4 my-3"><br>在庫情報</p>
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th scope="col"></th>
-          <th scope="col">商品名</th>
-          <th scope="col">在庫数</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render partial: "item" ,collection:  @items%>
-      </tbody>
-    </table>
+    <% if @shop.items.present? %>
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th scope="col">No.</th>
+            <th scope="col">商品名</th>
+            <th scope="col">在庫数</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: "item" ,collection:  @shop.items%>
+        </tbody>
+      </table>
+    <% else %>
+      商品はまだありません。
+    <% end %>
   </div>
 </div>
 <%= render "shared/footer"%>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,12 +4,12 @@
     <ul class="lists-left">
     <li><%= link_to  edit_shop_path(@shop), class: "btn btn-success m-3" do%>
     店舗情報を編集する<i class="fa fa-edit mx-1"></i><% end %></li>
-    <li><%= link_to  "#", class: "btn btn-success m-3" do%>
-    在庫を編集する<i class="fas fa-th mx-1"></i><% end %></li>
+    <li><%= link_to  new_shop_item_path(@shop), class: "btn btn-success m-3" do%>
+    在庫を編集する<i class="fas fa-boxes mx-1"></i><% end %></li>
     <li><%= link_to  shop_path(@shop), method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class: "btn btn-danger m-3" do%>
     店舗を削除する<i class="far fa-trash-alt mx-1"></i><% end %></li>
     <li><%= link_to  shops_path, class: "btn btn-secondary m-3" do%>
-    店舗一覧に戻る<i class="fa fa-edit mx-1"></i><% end %></li>
+    店舗一覧に戻る<i class="fas fa-angle-double-left mx-1"></i><% end %></li>
     </ul>
   </div>
   <div class="col-md-10 mx-auto">
@@ -61,12 +61,11 @@
       <table class="table table-hover">
         <thead>
           <tr>
-            <th scope="col">No.</th>
             <th scope="col">商品名</th>
             <th scope="col">在庫数</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody id="items">
           <%= render partial: "item" ,collection:  @shop.items%>
         </tbody>
       </table>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -2,16 +2,16 @@
 <div class="container my-3">
   <div class="nav">
     <ul class="lists-left">
-    <li><%= link_to  edit_shop_path(@shop), class: "btn btn-secondary m-3" do%>
+    <li><%= link_to  edit_shop_path(@shop), class: "btn btn-success m-3" do%>
     店舗を編集する<i class="fa fa-edit mx-1"></i><% end %></li>
     <li><%= link_to  shop_path(@shop), method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class: "btn btn-danger m-3" do%>
     店舗を削除する<i class="fa fa-edit mx-1"></i><% end %></li>
+    <li><%= link_to  shops_path, class: "btn btn-secondary m-3" do%>
+    店舗一覧に戻る<i class="fa fa-edit mx-1"></i><% end %></li>
     </ul>
   </div>
   <div class="col-md-10 mx-auto">
-    <% if @shop.image.attached? %>
-      <%= image_tag @shop.image, class: 'card-img-top' %>
-    <% elsif @shop.shop_image? %>
+    <% if @shop.shop_image? %>
       <%= image_tag @shop.shop_image.url, class: 'card-img-top' %>
     <% else %>
       <%= image_tag "/yaoya.png", class:"card-img-top" %>

--- a/app/views/items/new.erb
+++ b/app/views/items/new.erb
@@ -1,0 +1,41 @@
+<%= render "shared/header"%>
+<div class="container my-3">
+  <div class="nav">
+    <ul class="lists-left">
+    <li><%= link_to  shop_items_path(@shop), class: "btn btn-secondary m-3" do%>
+    店舗ページに戻る<i class="fas fa-angle-left mx-1"></i><% end %></li>
+    <li><%= link_to  shops_path, class: "btn btn-secondary m-3" do%>
+    店舗一覧に戻る<i class="fas fa-angle-double-left mx-1"></i><% end %></li>
+    </ul>
+  </div>
+  <div class="col-md-10 mx-auto">
+    <p class="font-weight-bold h3"><br><%= "#{@shop.name}の在庫情報編集" %></p>
+
+    <%= form_with model: [@shop, @item] do |f| %>
+      商品名：<%= f.text_field :name %>
+      在庫数：<%= f.number_field :count,min: 0, max: 10, value: 1%>
+      <%= f.submit '追加' ,class:"btn btn-primary"%>
+    <% end %>
+
+    <p class="font-weight-bold h4 my-3"><br><%= "#{@shop.name}の在庫情報" %></p>
+    <% if @shop.items.present? %>
+      <div hidden id="items_empty">商品はまだありません。</div>
+      <table class="table table-hover",  id="items_table">
+    <% else %>
+      <div id="items_empty">商品はまだありません。</div>
+      <table hidden class="table table-hover", id="items_table">
+    <% end %>
+        <thead>
+          <tr>
+            <th scope="col">商品名</th>
+            <th scope="col">在庫数</th>
+            <th scope="col"></th>
+          </tr>
+        </thead>
+        <tbody id="items">
+          <%= render partial: "item" ,collection:  @shop.items%>
+        </tbody>
+      </table>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/shops/destroy.erb
+++ b/app/views/shops/destroy.erb
@@ -4,7 +4,7 @@
     削除しました
   </div>
     <div class = "text-center">
-    <%= link_to '店舗一覧ページに戻る', shops_path ,class: "btn btn-light mx-auto" %>
+    <%= link_to '店舗一覧に戻る', shops_path ,class: "btn btn-secondary mx-auto" %>
   </div>
 </div>
 <%= render "shared/second-footer"%>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -2,7 +2,7 @@
 <div class="container my-3">
   <div class='nav'>
     <ul class='lists-left'>
-      <li><%= link_to new_shop_path, class: "btn btn-success mr-1" do%>
+      <li><%= link_to new_shop_path, class: "btn btn-primary mr-1" do%>
       店舗を作成する<i class="fas fa-store mx-1"></i></i><% end %></li>
     </ul>
   </div>

--- a/app/views/shops/update.html.erb
+++ b/app/views/shops/update.html.erb
@@ -4,7 +4,7 @@
     変更しました
   </div>
   <div class = "text-center">
-    <%= link_to '店舗ページに戻る', shop_items_path(@shop) ,class: "btn btn-light mx-auto" %>
+    <%= link_to '店舗ページに戻る', shop_items_path(@shop) ,class: "btn btn-secondary mx-auto" %>
   </div>
 </div>
 <%= render "shared/second-footer"%>

--- a/spec/channels/item_channel_spec.rb
+++ b/spec/channels/item_channel_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ItemChannel, type: :channel do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
- 店舗詳細在庫一覧ページに在庫編集ボタンを追加
- 在庫がない状態に在庫の表示自体の表示をhiddenにし、一個以上ある場合にhiddenを外した
- turbolinksを無効化
- ActionCableを実装
# Why
- 店舗詳細在庫一覧ページから在庫編集ページに飛ぶことが合理的であると考えられるため
- 在庫の有無で表示を適切に変更するため
- turbolinksが有効だとJSが読み込まれない可能性があるため
- ActionCableを用いて非同期で在庫情報の追加を行うため

close #10  