### PR TITLE
一般ユーザ管理機能#14

### DIFF
--- a/app/assets/stylesheets/entrances.scss
+++ b/app/assets/stylesheets/entrances.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the entrances controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admins/registrations_controller.rb
+++ b/app/controllers/admins/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 class Admins::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   # def new
@@ -38,7 +38,7 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
@@ -46,9 +46,15 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   # end
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+  def configure_account_update_params
+    # 情報更新時にnameの取得を許可
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    binding.pry
+  end
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/controllers/admins/registrations_controller.rb
+++ b/app/controllers/admins/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 class Admins::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
-  before_action :configure_account_update_params, only: [:update]
+  # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   # def new
@@ -46,11 +46,9 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   # end
 
   # If you have extra params to permit, append them to the sanitizer.
-  def configure_account_update_params
-    # 情報更新時にnameの取得を許可
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
-    binding.pry
-  end
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
 
   def update_resource(resource, params)
     resource.update_without_password(params)

--- a/app/controllers/admins/registrations_controller.rb
+++ b/app/controllers/admins/registrations_controller.rb
@@ -6,9 +6,7 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_account_update_params, only: [:update]
 
   def check_guest
-    if resource.email == 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザの変更・削除できません'
-    end
+    redirect_to root_path, alert: 'ゲストユーザの変更・削除できません' if resource.email == 'guest@example.com'
   end
   # GET /resource/sign_up
   # def new
@@ -58,7 +56,6 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   # def configure_account_update_params
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
   # end
-
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/controllers/admins/registrations_controller.rb
+++ b/app/controllers/admins/registrations_controller.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 class Admins::RegistrationsController < Devise::RegistrationsController
+  before_action :check_guest, only: [:destroy, :update]
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  def check_guest
+    if resource.email == 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザの変更・削除できません'
+    end
+  end
   # GET /resource/sign_up
   # def new
   #   super
@@ -40,6 +46,9 @@ class Admins::RegistrationsController < Devise::RegistrationsController
 
   protected
 
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
@@ -50,9 +59,6 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
   # end
 
-  def update_resource(resource, params)
-    resource.update_without_password(params)
-  end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/controllers/admins/sessions_controller.rb
+++ b/app/controllers/admins/sessions_controller.rb
@@ -3,6 +3,12 @@
 class Admins::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
+  def new_guest
+    admin = Admin.guest
+    sign_in admin
+    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました。'
+  end
+
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,12 +9,19 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
+    # 新規登録時にnameの取得を許可
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    # 編集時にnameの取得を許可
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']  # 環境変数を読み込む記述に変更
     end
+  end
+
+  def authenticate_user_admin!
+    redirect_to root_path unless user_signed_in? || admin_signed_in?
   end
 end

--- a/app/controllers/entrances_controller.rb
+++ b/app/controllers/entrances_controller.rb
@@ -4,4 +4,7 @@ class EntrancesController < ApplicationController
 
   def sessions
   end
+
+  def user_chanege_desroy
+  end
 end

--- a/app/controllers/entrances_controller.rb
+++ b/app/controllers/entrances_controller.rb
@@ -1,0 +1,7 @@
+class EntrancesController < ApplicationController
+  def registrations
+  end
+
+  def sessions
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,10 +1,15 @@
 class FavoritesController < ApplicationController
-  before_action :authenticate_admin!
+  before_action :authenticate_user_admin!
   before_action :set_shop, only: [:create, :destroy]
 
   def index
-    @shops = current_admin.favorite_shops.page(params[:page]).per(PER)
-    @shop_count = current_admin.favorite_shops.count
+    if user_signed_in?
+      @shops = current_user.favorite_shops.page(params[:page]).per(PER)
+      @shop_count = current_user.favorite_shops.count
+    elsif admin_signed_in?
+      @shops = current_admin.favorite_shops.page(params[:page]).per(PER)
+      @shop_count = current_admin.favorite_shops.count
+    end
   end
 
   def create
@@ -29,5 +34,4 @@ class FavoritesController < ApplicationController
   def set_shop
     @shop = Shop.find(params[:shop_id])
   end
-
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -31,6 +31,7 @@ class FavoritesController < ApplicationController
   end
 
   private
+
   def set_shop
     @shop = Shop.find(params[:shop_id])
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
@@ -49,6 +49,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def configure_account_update_params
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
   # end
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/helpers/entrances_helper.rb
+++ b/app/helpers/entrances_helper.rb
@@ -1,0 +1,2 @@
+module EntrancesHelper
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -20,13 +20,8 @@ class Admin < ApplicationRecord
   end
 
   def self.guest
-    find_or_create_by!(name: 'amano', email: 'z@z') do |admin|
+    find_or_create_by!(name: 'GUEST', email: 'guest@example.com') do |admin|
       admin.password = SecureRandom.hex(10)
     end
   end
-  # def self.guest
-  #   find_or_create_by!(name: 'GUEST', email: 'guest@example.com') do |admin|
-  #     admin.password = SecureRandom.hex(10)
-  #   end
-  # end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -8,7 +8,6 @@ class Admin < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_shops, through: :favorites, source: :shop
 
-
   with_options presence: true do
     validates :name
     with_options format: { with: /\A(?=.*?[a-z])[a-z\d]+\z/i } do

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -8,10 +8,14 @@ class Admin < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_shops, through: :favorites, source: :shop
 
-  with_options presence: true do
+  with_options presence: true, on: :create do
     validates :name
-    with_options format: { with: /\A(?=.*?[a-z])[a-z\d]+\z/i } do
+    with_options format: { with: /\A[a-z0-9]+\z/i } do
       validates :password
     end
+  end
+
+  with_options presence: true, on: :update do
+    validates :name
   end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -18,4 +18,15 @@ class Admin < ApplicationRecord
   with_options presence: true, on: :update do
     validates :name
   end
+
+  def self.guest
+    find_or_create_by!(name: 'amano', email: 'z@z') do |admin|
+      admin.password = SecureRandom.hex(10)
+    end
+  end
+  # def self.guest
+  #   find_or_create_by!(name: 'GUEST', email: 'guest@example.com') do |admin|
+  #     admin.password = SecureRandom.hex(10)
+  #   end
+  # end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -5,6 +5,4 @@ class Favorite < ApplicationRecord
 
   validates_uniqueness_of :shop_id, scope: :user_id, if: :user_id
   validates_uniqueness_of :shop_id, scope: :admin_id, if: :admin_id
-
-
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -7,8 +7,6 @@ class Shop < ApplicationRecord
   has_many :favorite_admins, through: :favorites, source: :admin
   has_many :favorite_users, through: :favorites, source: :user
 
-
-
   with_options presence: true do
     validates :name,             length: { maximum: 40 }
     validates :location,         length: { maximum: 1000 }
@@ -39,9 +37,8 @@ class Shop < ApplicationRecord
   end
 
   # ログインしているユーザーがブログをいいねしているがどうか判断するメソッド
-	def favorited_by?(user)
+  def favorited_by?(user)
     # Shop.favoritesが省略されている
     favorites.where(user_id: user.id).exists? || favorites.where(admin_id: user.id).exists?
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,14 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_shops, through: :favorites, source: :shop
 
-  with_options presence: true do
+  with_options presence: true, on: :create do
     validates :name
     with_options format: { with: /\A(?=.*?[a-z])[a-z\d]+\z/i } do
       validates :password
     end
+  end
+
+  with_options presence: true, on: :update do
+    validates :name
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   with_options presence: true, on: :create do
     validates :name
-    with_options format: { with: /\A(?=.*?[a-z])[a-z\d]+\z/i } do
+    with_options format: { with: /\A[a-z0-9]+\z/i } do
       validates :password
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,10 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_shops, through: :favorites, source: :shop
 
+  with_options presence: true do
+    validates :name
+    with_options format: { with: /\A(?=.*?[a-z])[a-z\d]+\z/i } do
+      validates :password
+    end
+  end
 end

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,43 +1,20 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "admins/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<%= render "shared/second-header"%>
+  <div class="registration-main">
+    <div class="form-wrap alert-dark">
+      <div class='form-header'>
+        <div class='font-wight-bold h1 py-3'>
+          ユーザー情報変更
+        </div>
+      </div>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render partial: "shared/registration_update_form", locals: { f: f } %>
+        <div class='register-btn mt-4'>
+          <%= button_tag type: 'submit', class: "btn btn-block btn-outline-primary" do %>
+            情報変更<i class="fas fa-user-cog mx-1 mx-1"></i>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/admins/registrations/new.html.erb
+++ b/app/views/admins/registrations/new.html.erb
@@ -1,54 +1,18 @@
 <%= render "shared/second-header"%>
 
 <%= form_with model: @admin, url: admin_registration_path, class: 'registration-main', local: true do |f| %>
-<div class='form-wrap'>
+<div class='form-wrap alert-dark'>
   <div class='form-header'>
-    <h1 class='form-header-text'>
-      ショップ会員情報入力
-    </h1>
-  </div>
-
-  <%= render 'shared/error_messages', model: f.object %>
-
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">アカウント名<i class="fas fa-user mx-1"></i>
-      <span class="badge badge-danger">必須</span></label>
+    <div class='font-wight-bold h1 py-5'>
+      店舗ユーザー情報入力
     </div>
-    <%= f.text_field :name, class:"input-default", id:"name", placeholder:"例) 八百屋", maxlength:"40", autofocus: true%>
   </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">メールアドレス<i class="far fa-envelope mx-1"></i>
-      <span class="badge badge-danger">必須</span></label>
-    </div>
-    <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可" %>
+  <%= render partial: "shared/registration_form" ,locals: { f: f } %>
+  <div class='register-btn mt-4'>
+    <%= button_tag type: 'submit', class: "btn btn-block btn-outline-dark" do %>
+      会員登録<i class="fas fa-user-plus mx-1 mx-1"></i>
+    <% end %>
   </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">パスワード<i class="fas fa-key mx-1"></i>
-      <span class="badge badge-danger">必須</span></label>
-    </div>
-    <%= f.password_field :password, class:"input-default", id:"password", placeholder:"6文字以上の半角英数字" %>
-  </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">パスワード(確認)<i class="fas fa-key mx-1"></i>
-      <span class="badge badge-danger">必須</span></label>
-    </div>
-    <%= f.password_field :password_confirmation, class:"input-default", id:"password-confirmation", placeholder:"同じパスワードを入力して下さい" %>
-  </div>
-  <div class="form-group">
-    <h2 class='form-bottom-text'>
-      「会員登録」のボタンを押すことにより、
-      <span>利用規約</span>
-      <br>に同意したものとみなします
-    </h2>
-  </div>
-  <div class='register-btn'>
-    <%= f.submit "会員登録" ,class:"btn btn-block  btn-outline-primary" %>
-  </div>
-  <p class='register-info'>本人情報の登録について</p>
 </div>
 <% end %>
 

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -1,37 +1,13 @@
 <%= render "shared/second-header"%>
 
 <%= form_with model: @admin, url: admin_session_path, class: 'registration-main', local: true do |f| %>
-<div class='form-wrap'>
+<div class='form-wrap alert-dark'>
   <div class='form-header'>
-    <h1 class='form-header-text'>
-      ショップ会員情報入力
-    </h1>
-  </div>
-  <div class='login-flash-message'>
-    <%= flash[:notice] %>
-    <%= flash[:alert] %>
-  </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">メールアドレス<i class="far fa-envelope mx-1"></i>
-      <span class="badge badge-danger">必須</span></label>
+    <div class='font-wight-bold h1 py-5'>
+      店舗ユーザーログイン
     </div>
-    <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可", autofocus: true %>
   </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">パスワード<i class="fas fa-key mx-1"></i>
-      <span class="badge badge-danger">必須</span></label>
-    </div>
-    <%= f.password_field :password, class:"input-default", id:"password", placeholder:"" %>
-  </div>
-  <div class='login-btn'>
-    <%= button_tag type: 'submit', class: "btn btn-block btn-primary" do %>
-    ログイン<i class="fas fa-sign-in-alt mx-1"></i>
-    <% end %>
-    <%# submitでアイコンを設定したい場合button_tagを使用する %>
-    <%#= f.submit "ログイン" ,class:"btn btn-block  btn-outline-primary" %>
-  </div>
+  <%= render partial: "shared/session_form" ,locals: { f: f } %>
 </div>
 <% end %>
 

--- a/app/views/entrances/registrations.html.erb
+++ b/app/views/entrances/registrations.html.erb
@@ -1,17 +1,17 @@
 <%= render "shared/header"%>
 <div class="container my-3">
   <div class="font-weight-bold h1 m-3 text-center">新規登録</div>
-  <div class="h2 m-3 text-center">登録するアカウントの種類を選んでください！</div>
+  <div class="h2 m-3 text-center">登録するアカウントの種類を選んでください</div>
   <div class="row justify-content-around p-5 mb-5">
     <div class="col-md-4 h-auto alert alert-primary text-center py-5 btn">
       <%= link_to  new_user_registration_path, class:"text-reset" do%>
-        <div class="h1">見るだけ！</div>
+        <div class="h1">見るだけ<i class="fas fa-user h3 mx-2"></i></div>
         <div class="h5">一般ユーザー登録</div>
       <% end %>
     </div>
-    <div class="col-md-4 h-auto alert alert-secondary text-center py-5 btn">
+    <div class="col-md-4 h-auto alert alert-dark text-center py-5 btn">
       <%= link_to  new_admin_registration_path, class:"text-reset" do%>
-        <div class="h1 ">出店する！</div>
+        <div class="h1 ">出店する<i class="fas fa-store h3 mx-2"></i></div>
         <div class="h5">店舗ユーザー登録</div>
       <% end %>
     </div>

--- a/app/views/entrances/registrations.html.erb
+++ b/app/views/entrances/registrations.html.erb
@@ -1,0 +1,24 @@
+<%= render "shared/header"%>
+<div class="container my-3">
+  <div class="font-weight-bold h1 m-3 text-center">新規登録</div>
+  <div class="h2 m-3 text-center">登録するアカウントの種類を選んでください！</div>
+  <div class="row justify-content-around p-5 mb-5">
+    <div class="col-md-4 h-auto alert alert-primary text-center py-5 btn">
+      <%= link_to  new_user_registration_path, class:"text-reset" do%>
+        <div class="h1">見るだけ！</div>
+        <div class="h5">一般ユーザー登録</div>
+      <% end %>
+    </div>
+    <div class="col-md-4 h-auto alert alert-secondary text-center py-5 btn">
+      <%= link_to  new_admin_registration_path, class:"text-reset" do%>
+        <div class="h1 ">出店する！</div>
+        <div class="h5">店舗ユーザー登録</div>
+      <% end %>
+    </div>
+  </div>
+  <div class="text-right">
+  <%= link_to  "簡単ログイン、通常ログインはこちら", entrances_sessions_path, class: "h4"%>
+  </div>
+
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/entrances/registrations.html.erb
+++ b/app/views/entrances/registrations.html.erb
@@ -17,7 +17,7 @@
     </div>
   </div>
   <div class="text-right">
-  <%= link_to  "簡単ログイン、通常ログインはこちら", entrances_sessions_path, class: "h4"%>
+  <%= link_to  "ログインはこちら", entrances_sessions_path, class: "h4"%>
   </div>
 
 </div>

--- a/app/views/entrances/sessions.html.erb
+++ b/app/views/entrances/sessions.html.erb
@@ -1,11 +1,11 @@
 <%= render "shared/header"%>
 <div class="container my-3">
   <div class="font-weight-bold h1 m-3 text-center">ログイン</div>
-  <div class="h2 m-3 text-center">ログインのするアカウントの種類を選んでください！</div>
+  <div class="h2 m-3 text-center">ログインのするアカウントの種類を選んでください</div>
   <div class="row justify-content-around p-5 mb-5">
     <div class="col-md-4 h-auto alert alert-primary h1 text-center py-5 px-0 btn">
       <%= link_to  new_user_session_path, class:"text-reset" do%>
-        <div class="h1">一般ユーザー</div>
+        <div class="h1">一般ユーザー<i class="fas fa-user h3 mx-2"></i></div>
       <% end %>
     </div>
     <div class="col-md-3 h-auto alert alert-warning h1 text-center py-5 px-0 btn">
@@ -13,9 +13,9 @@
         <div class="h1">簡単ログイン</div>
       <% end %>
     </div>
-    <div class="col-md-4 h-auto alert alert-secondary h1 text-center py-5 px-0 btn">
+    <div class="col-md-4 h-auto alert alert-dark h1 text-center py-5 px-0 btn">
       <%= link_to  new_admin_session_path, class:"text-reset" do%>
-        <div class="h1">店舗ユーザー</div>
+        <div class="h1">店舗ユーザー<i class="fas fa-store h3 mx-2"></i></div>
       <% end %>
     </div>
   </div>

--- a/app/views/entrances/sessions.html.erb
+++ b/app/views/entrances/sessions.html.erb
@@ -8,11 +8,6 @@
         <div class="h1">一般ユーザー<i class="fas fa-user h3 mx-2"></i></div>
       <% end %>
     </div>
-    <div class="col-md-3 h-auto alert alert-warning h1 text-center py-5 px-0 btn">
-      <%= link_to  "#", class:"text-reset" do%>
-        <div class="h1">簡単ログイン</div>
-      <% end %>
-    </div>
     <div class="col-md-4 h-auto alert alert-dark h1 text-center py-5 px-0 btn">
       <%= link_to  new_admin_session_path, class:"text-reset" do%>
         <div class="h1">店舗ユーザー<i class="fas fa-store h3 mx-2"></i></div>

--- a/app/views/entrances/sessions.html.erb
+++ b/app/views/entrances/sessions.html.erb
@@ -1,0 +1,27 @@
+<%= render "shared/header"%>
+<div class="container my-3">
+  <div class="font-weight-bold h1 m-3 text-center">ログイン</div>
+  <div class="h2 m-3 text-center">ログインのするアカウントの種類を選んでください！</div>
+  <div class="row justify-content-around p-5 mb-5">
+    <div class="col-md-4 h-auto alert alert-primary h1 text-center py-5 px-0 btn">
+      <%= link_to  new_user_session_path, class:"text-reset" do%>
+        <div class="h1">一般ユーザー</div>
+      <% end %>
+    </div>
+    <div class="col-md-3 h-auto alert alert-warning h1 text-center py-5 px-0 btn">
+      <%= link_to  "#", class:"text-reset" do%>
+        <div class="h1">簡単ログイン</div>
+      <% end %>
+    </div>
+    <div class="col-md-4 h-auto alert alert-secondary h1 text-center py-5 px-0 btn">
+      <%= link_to  new_admin_session_path, class:"text-reset" do%>
+        <div class="h1">店舗ユーザー</div>
+      <% end %>
+    </div>
+  </div>
+  <div class="text-right">
+  <%= link_to  "新規登録はこちら", entrances_registrations_path, class: "h4"%>
+  </div>
+
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/entrances/user_chanege_desroy.html.erb
+++ b/app/views/entrances/user_chanege_desroy.html.erb
@@ -1,0 +1,20 @@
+<%= render "shared/header"%>
+<div class="container my-3">
+  <div class="font-weight-bold h1 m-3 text-center">登録変更</div>
+  <div class="h2 m-3 text-center">アカウントに行う処理を選んでください</div>
+  <div class="row justify-content-around p-5 mb-5">
+    <div class="col-md-4 h-auto alert alert-info text-center py-5 btn">
+      <%= link_to  edit_user_registration_path, class:"text-reset" do%>
+        <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
+        <div class="h5">ユーザー情報変更</div>
+      <% end %>
+    </div>
+    <div class="col-md-4 h-auto alert alert-danger text-center py-5 btn">
+      <%= link_to  user_registration_path, method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class:"text-reset" do%>
+        <div class="h1 ">削除する<i class="fas fa-user-slash h3 mx-2"></i></div>
+        <div class="h5">ユーザー情報削除</div>
+      <% end %>
+    </div>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,6 +1,12 @@
 <%= render "shared/header"%>
 <div class="container my-3">
-  <div class="font-weight-bold h2"><%= "#{current_admin.name}さんのお気に入り店舗一覧 全#{@shop_count}店" %></div>
+  <div class="font-weight-bold h2">
+  <% if user_signed_in? %>
+    <%= "#{current_user.name}さんのお気に入り店舗一覧 全#{@shop_count}店" %>
+  <% elsif admin_signed_in? %>
+    <%= "#{current_admin.name}さんのお気に入り店舗一覧 全#{@shop_count}店" %>
+  <% end %>
+  </div>
   <div class="row">
     <%= render partial: "shops/shop" ,collection:  @shops%>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= favicon_link_tag('favicon.ico') %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
@@ -13,7 +14,6 @@
     <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
 
 
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   </head>
 
   <body>

--- a/app/views/shared/_favorite.html.erb
+++ b/app/views/shared/_favorite.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 <% elsif user_signed_in? %>
   <% if shop.favorited_by?(current_user) %>
-    <%=link_to  shop_favorite_path(shop.id, current_admin.id), class: "text-danger", method: :delete, remote: true do %>
+    <%=link_to  shop_favorite_path(shop.id, current_user.id), class: "text-danger", method: :delete, remote: true do %>
       <i class="fas fa-heart"><%= shop.favorites.count %></i>
     <% end %>
   <% else %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -42,6 +42,9 @@
         <li><%= link_to  destroy_user_session_path, method: :delete, class: "btn btn-outline-secondary" do%>
         ログアウト<i class="fas fa-sign-out-alt mx-1"></i><% end %></li>
       <% else %>
+        <li><%= link_to  admins_guest_sign_in_path, method: :post, class: "btn btn-success mr-1" do%>
+          簡単ログイン<i class="fas fa-star mx-1"></i>
+        <% end %></li>
         <li><%= link_to  entrances_sessions_path, class: "btn btn-primary mr-1" do%>
           ログイン<i class="fas fa-sign-in-alt mx-1"></i>
         <% end %></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,12 +24,22 @@
         <li><%= link_to favorites_path, class: "btn btn-warning text-white mr-1" do%>
         お気に入り一覧<i class="fas fa-heart mx-1"></i></i><% end %></li>
       </ul>
+    <% elsif user_signed_in? %>
+      <ul class='d-flex justify-content-start'>
+        <li><%= link_to favorites_path, class: "btn btn-warning text-white mr-1" do%>
+        お気に入り一覧<i class="fas fa-heart mx-1"></i></i><% end %></li>
+      </ul>
     <% end %>
     <ul class='d-flex justify-content-end ml-auto'>
       <% if admin_signed_in?%>
         <li><%= link_to my_shops_path, class: "btn btn-info mr-1" do%>
         <%= current_admin.name %><i class="fas fa-user mx-1"></i><% end %></li>
         <li><%= link_to  destroy_admin_session_path, method: :delete, class: "btn btn-outline-secondary" do%>
+        ログアウト<i class="fas fa-sign-out-alt mx-1"></i><% end %></li>
+      <% elsif user_signed_in? %>
+        <li><%= link_to entrances_user_chanege_desroy_path, class: "btn btn-info mr-1" do%>
+        <%= current_user.name %><i class="fas fa-user mx-1"></i><% end %></li>
+        <li><%= link_to  destroy_user_session_path, method: :delete, class: "btn btn-outline-secondary" do%>
         ログアウト<i class="fas fa-sign-out-alt mx-1"></i><% end %></li>
       <% else %>
         <li><%= link_to  entrances_sessions_path, class: "btn btn-primary mr-1" do%>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -32,10 +32,10 @@
         <li><%= link_to  destroy_admin_session_path, method: :delete, class: "btn btn-outline-secondary" do%>
         ログアウト<i class="fas fa-sign-out-alt mx-1"></i><% end %></li>
       <% else %>
-        <li><%= link_to  new_admin_session_path, class: "btn btn-primary mr-1" do%>
+        <li><%= link_to  entrances_sessions_path, class: "btn btn-primary mr-1" do%>
           ログイン<i class="fas fa-sign-in-alt mx-1"></i>
         <% end %></li>
-        <li><%= link_to  new_admin_registration_path, class: "btn btn-outline-primary" do%>
+        <li><%= link_to  entrances_registrations_path, class: "btn btn-outline-primary" do%>
           新規登録<i class="fas fa-user-plus mx-1"></i>
         <% end %></li>
       <% end %>

--- a/app/views/shared/_registration_form.html.erb
+++ b/app/views/shared/_registration_form.html.erb
@@ -1,0 +1,30 @@
+<%= render 'shared/error_messages', model: f.object %>
+
+<div class="form-group">
+  <div class='form-text-wrap'>
+    <label class="form-text">アカウント名<i class="fas fa-user mx-1"></i>
+    <span class="badge badge-danger">必須</span></label>
+  </div>
+  <%= f.text_field :name, class:"input-default", id:"name", placeholder:"公開されません", maxlength:"40", autofocus: true%>
+</div>
+<div class="form-group">
+  <div class='form-text-wrap'>
+    <label class="form-text">メールアドレス<i class="far fa-envelope mx-1"></i>
+    <span class="badge badge-danger">必須</span></label>
+  </div>
+  <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可" %>
+</div>
+<div class="form-group">
+  <div class='form-text-wrap'>
+    <label class="form-text">パスワード<i class="fas fa-key mx-1"></i>
+    <span class="badge badge-danger">必須</span></label>
+  </div>
+  <%= f.password_field :password, class:"input-default", id:"password", placeholder:"6文字以上の半角英数字" %>
+</div>
+<div class="form-group">
+  <div class='form-text-wrap'>
+    <label class="form-text">パスワード(確認)<i class="fas fa-key mx-1"></i>
+    <span class="badge badge-danger">必須</span></label>
+  </div>
+  <%= f.password_field :password_confirmation, class:"input-default", id:"password-confirmation", placeholder:"同じパスワードを入力して下さい" %>
+</div>

--- a/app/views/shared/_registration_update_form.html.erb
+++ b/app/views/shared/_registration_update_form.html.erb
@@ -1,0 +1,9 @@
+<%= render "devise/shared/error_messages", resource: resource %>
+<div class = 'form-group'>
+  <div class='form-text-wrap'><%= f.label :name, "ユーザー名" %></div>
+  <%= f.text_field :name, autofocus: true, class: "form-control", placeholder: "最大10文字", maxlength: 10 %>
+</div>
+<div class = 'form-group'>
+  <div class='form-text-wrap'><%= f.label :email, "メールアドレス" %></div>
+  <%= f.email_field :email, autocomplete: "email", class: "form-control", placeholder: "xxx@email.com" %>
+</div>

--- a/app/views/shared/_session_form.html.erb
+++ b/app/views/shared/_session_form.html.erb
@@ -1,0 +1,24 @@
+<div class='login-flash-message'>
+  <%= flash[:notice] %>
+  <%= flash[:alert] %>
+</div>
+<div class="form-group">
+  <div class='form-text-wrap'>
+    <label class="form-text">メールアドレス<i class="far fa-envelope mx-1"></i>
+    <span class="badge badge-danger">必須</span></label>
+  </div>
+  <%= f.email_field :email, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可", autofocus: true %>
+</div>
+<div class="form-group">
+  <div class='form-text-wrap'>
+    <label class="form-text">パスワード<i class="fas fa-key mx-1"></i>
+    <span class="badge badge-danger">必須</span></label>
+  </div>
+  <%= f.password_field :password, class:"input-default", id:"password", placeholder:"" %>
+</div>
+<div class='login-btn'>
+  <%= button_tag type: 'submit', class: "btn btn-block btn-primary" do %>
+  ログイン<i class="fas fa-sign-in-alt mx-1"></i>
+  <% end %>
+  <%# submitでアイコンを設定したい場合button_tagを使用する %>
+</div>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,5 +1,7 @@
 <%= render "shared/header"%>
 <div class="container my-3">
+  <div class="alert-primary" role="alert"><%= flash[:notice] %></div>
+  <div class="alert-danger" role="alert"><%= flash[:alert] %></div>
   <div class="font-weight-bold h2"><%= "店舗一覧 全#{@shop_count}店" %></div>
   <div class="row">
     <%= render partial: "shop" ,collection:  @shops%>

--- a/app/views/shops/my.html.erb
+++ b/app/views/shops/my.html.erb
@@ -1,5 +1,22 @@
 <%= render "shared/header"%>
 <div class="container my-3">
+  <div class="font-weight-bold h1 m-3 text-center">登録変更</div>
+  <div class="h2 m-3 text-center">アカウントに行う処理を選んでください</div>
+  <div class="row justify-content-around p-5 mb-5">
+    <div class="col-md-4 h-auto alert alert-info text-center py-5 btn">
+      <%= link_to  edit_admin_registration_path, class:"text-reset" do%>
+        <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
+        <div class="h5">ユーザー情報変更</div>
+      <% end %>
+    </div>
+    <div class="col-md-4 h-auto alert alert-danger text-center py-5 btn">
+      <%= link_to  admin_registration_path, method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class:"text-reset" do%>
+        <div class="h1 ">削除する<i class="fas fa-user-slash h3 mx-2"></i></div>
+        <div class="h5">ユーザー情報削除</div>
+      <% end %>
+    </div>
+  </div>
+
   <div class="font-weight-bold h2"><%= "#{current_admin.name}さんの店舗一覧 全#{@shop_count}店" %></div>
   <div class="row">
     <%= render partial: "shop" ,collection:  @shops%>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,43 +1,20 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<%= render "shared/second-header"%>
+  <div class="registration-main">
+    <div class="form-wrap alert-primary">
+      <div class='form-header'>
+        <div class='font-wight-bold h1 py-3'>
+          ユーザー情報変更
+        </div>
+      </div>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render partial: "shared/registration_update_form", locals: { f: f } %>
+        <div class='register-btn mt-4'>
+          <%= button_tag type: 'submit', class: "btn btn-block btn-outline-primary" do %>
+            情報変更<i class="fas fa-user-cog mx-1 mx-1"></i>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,107 +1,18 @@
 <%= render "shared/second-header"%>
 
-<%# 「モデル名」にはUserモデルであれば@userを渡しましょう。「新規登録機能へのパス」は、devise導入後にrails routesを実行してdevise/registrations#createへのパスを確認し、記載してください。 %>
-<%= form_with url: "#", class: 'registration-main', local: true do |f| %>
-<%# //「モデル名」にはUserモデルであれば@userを渡しましょう。「新規登録機能へのパス」は、devise導入後にrails routesを実行してdevise/registrations#createへのパスを確認し、記載してください。 %>
-<div class='form-wrap'>
+<%= form_with model: @user, url: user_registration_path, class: 'registration-main', local: true do |f| %>
+<div class='form-wrap alert-primary'>
   <div class='form-header'>
-    <h1 class='form-header-text'>
-      会員情報入力
-    </h1>
-  </div>
-
-  <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-  <%# render 'shared/error_messages', model: f.object %>
-  <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">ニックネーム</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <%= f.text_area :hoge, class:"input-default", id:"nickname", placeholder:"例) furima太郎", maxlength:"40" %>
-  </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">メールアドレス</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <%= f.email_field :hoge, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可", autofocus: true %>
-  </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">パスワード</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <%= f.password_field :hoge, class:"input-default", id:"password", placeholder:"6文字以上の半角英数字" %>
-    <p class='info-text'>※英字と数字の両方を含めて設定してください</p>
-  </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">パスワード(確認)</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <%= f.password_field :password_confirmation, class:"input-default", id:"password-confirmation", placeholder:"同じパスワードを入力して下さい" %>
-  </div>
-  <div class="form-group">
-    <p class='form-info-header'>
-      本人確認
-    </p>
-    <p class='form-info-text'>
-      安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
-    </p>
-  </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">お名前(全角)</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <div class='input-name-wrap'>
-      <%= f.text_area :hoge, class:"input-name", id:"last-name", placeholder:"例) 山田" %>
-      <%= f.text_area :hoge, class:"input-name", id:"first-name", placeholder:"例) 陸太郎" %>
+    <div class='font-wight-bold h1 py-5'>
+      一般ユーザー情報入力
     </div>
   </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">お名前カナ(全角)</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <div class='input-name-wrap'>
-      <%= f.text_area :hoge, class:"input-name", id:"last-name-kana", placeholder:"例) ヤマダ" %>
-      <%= f.text_area :hoge, class:"input-name", id:"first-name-kana", placeholder:"例) リクタロウ" %>
-    </div>
+  <%= render partial: "shared/registration_form" ,locals: { f: f } %>
+    <div class='register-btn mt-4'>
+    <%= button_tag type: 'submit', class: "btn btn-block btn-outline-primary" do %>
+      会員登録<i class="fas fa-user-plus mx-1 mx-1"></i>
+    <% end %>
   </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">生年月日</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <div class='input-birth-wrap'>
-      <%= raw sprintf(
-                  f.date_select(
-                    :hoge,
-                    class:'select-birth',
-                    id:"birth-date",
-                    use_month_numbers: true,
-                    prompt:'--',
-                    start_year: 1930,
-                    end_year: (Time.now.year - 5),
-                    date_separator: '%s'),
-                  "<p> 年 </p>", "<p> 月 </p>") + "<p> 日 </p>" %>
-    </div>
-    <p class='info-text'>※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。</p>
-  </div>
-  <div class="form-group">
-    <h2 class='form-bottom-text'>
-      「会員登録」のボタンを押すことにより、
-      <span>利用規約</span>
-      <br>に同意したものとみなします
-    </h2>
-  </div>
-  <div class='register-btn'>
-    <%= f.submit "会員登録" ,class:"register-red-btn" %>
-  </div>
-  <p class='register-info'>本人情報の登録について</p>
 </div>
 <% end %>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,33 +1,14 @@
 <%= render "shared/second-header"%>
 
-<%= form_with class: 'registration-main', local: true do |f| %>
-<div class='form-wrap'>
+<%= form_with model: @user, url: user_session_path, class: 'registration-main', local: true do |f| %>
+<div class='form-wrap alert-primary'>
   <div class='form-header'>
-    <h1 class='form-header-text'>
-      会員情報入力
-    </h1>
-  </div>
-  <div class='login-flash-message'>
-    <%= flash[:notice] %>
-    <%= flash[:alert] %>
-  </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">メールアドレス</label>
-      <span class="indispensable">必須</span>
+    <div class='font-wight-bold h1 py-5'>
+      一般ユーザーログイン
     </div>
-    <%= f.email_field :hoge, class:"input-default", id:"email", placeholder:"PC・携帯どちらでも可", autofocus: true %>
   </div>
-  <div class="form-group">
-    <div class='form-text-wrap'>
-      <label class="form-text">パスワード</label>
-      <span class="indispensable">必須</span>
-    </div>
-    <%= f.password_field :hoge, class:"input-default", id:"password", placeholder:"" %>
-  </div>
-  <div class='login-btn'>
-    <%= f.submit "ログイン" ,class:"login-red-btn" %>
-  </div>
+  <%= render partial: "shared/session_form" ,locals: { f: f } %>
+
 </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
   devise_scope :admin do
-    post 'admin/guest_sign_in', to: 'admin/sessions#new_guest'
+    post 'admins/guest_sign_in', to: 'admins/sessions#new_guest'
   end
 
   resources :shops do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,5 @@ Rails.application.routes.draw do
   get 'items/search'
   get 'entrances/registrations'
   get 'entrances/sessions'
+  get 'entrances/user_chanege_desroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
     passwords:     'users/passwords',
     registrations: 'users/registrations'
   }
+  devise_scope :admin do
+    post 'admin/guest_sign_in', to: 'admin/sessions#new_guest'
+  end
+
   resources :shops do
     resources :items
     resources :favorites , only: [:create, :destroy]
@@ -18,6 +22,9 @@ Rails.application.routes.draw do
       post :confirm
     end
   end
-  get 'items/search'
+
   resources :favorites , only: [:index]
+  get 'items/search'
+  get 'entrances/registrations'
+  get 'entrances/sessions'
 end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :favorite do
-    
   end
 end

--- a/spec/helpers/entrances_helper_spec.rb
+++ b/spec/helpers/entrances_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the EntrancesHelper. For example:
+#
+# describe EntrancesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe EntrancesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/entrances_request_spec.rb
+++ b/spec/requests/entrances_request_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe "Entrances", type: :request do
-
-  describe "GET /registrations" do
-    it "returns http success" do
-      get "/entrances/registrations"
+RSpec.describe 'Entrances', type: :request do
+  describe 'GET /registrations' do
+    it 'returns http success' do
+      get '/entrances/registrations'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /sessions" do
-    it "returns http success" do
-      get "/entrances/sessions"
+  describe 'GET /sessions' do
+    it 'returns http success' do
+      get '/entrances/sessions'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/entrances_request_spec.rb
+++ b/spec/requests/entrances_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "Entrances", type: :request do
+
+  describe "GET /registrations" do
+    it "returns http success" do
+      get "/entrances/registrations"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /sessions" do
+    it "returns http success" do
+      get "/entrances/sessions"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/favorites_request_spec.rb
+++ b/spec/requests/favorites_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Favorites", type: :request do
-
+RSpec.describe 'Favorites', type: :request do
 end

--- a/spec/views/entrances/registrations.html.erb_spec.rb
+++ b/spec/views/entrances/registrations.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "entrances/registrations.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/entrances/registrations.html.erb_spec.rb
+++ b/spec/views/entrances/registrations.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "entrances/registrations.html.erb", type: :view do
+RSpec.describe 'entrances/registrations.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/entrances/sessions.html.erb_spec.rb
+++ b/spec/views/entrances/sessions.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "entrances/sessions.html.erb", type: :view do
+RSpec.describe 'entrances/sessions.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/entrances/sessions.html.erb_spec.rb
+++ b/spec/views/entrances/sessions.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "entrances/sessions.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/logins/index.html.erb_spec.rb
+++ b/spec/views/logins/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "logins/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/logins/index.html.erb_spec.rb
+++ b/spec/views/logins/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "logins/index.html.erb", type: :view do
+RSpec.describe 'logins/index.html.erb', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
# What
- 店舗ユーザーと一般ユーザーのログインと新規登録の選択ページの作成
- ログイン画面のフロント統一、アイコン設置
- 簡単ログイン機能実装
# Why
- 二種類のユーザーを作成したため、各ログイン、新規登録へのリンクを設置するとページにリンクが多くなる。そのためログインと新規登録の選択の後にアカウントの種類の選択をさせた。
- 就活担当の方にみてもらう際に、ログイン機能は一つ手間となり、みてもらうためのハードルとなってしまう。ワンクリックでログインのできる簡単ログイン機能が有効だと考えた。削除や編集が行われるとその機能に支障が出るため、その対策も行った。

close #14 
close #38 
