### PR TITLE
登録変更画面のボタンの範囲 #59

### DIFF
--- a/app/controllers/entrances_controller.rb
+++ b/app/controllers/entrances_controller.rb
@@ -1,4 +1,5 @@
 class EntrancesController < ApplicationController
+  before_action :authenticate_user!, only: [:user_chanege_desroy]
   def registrations
   end
 

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -21,7 +21,7 @@ class Admin < ApplicationRecord
   end
 
   def self.guest
-    find_or_create_by!(name: 'GUEST', email: 'guest@example.com') do |admin|
+    find_or_create_by!(name: 'ゲスト', email: 'guest@example.com') do |admin|
       admin.password = SecureRandom.hex(10)
     end
   end

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,19 +1,19 @@
-<%= render "shared/second-header"%>
-  <div class="registration-main">
-    <div class="form-wrap alert-dark">
-      <div class='form-header'>
-        <div class='font-wight-bold h1 py-3'>
+<%= render "shared/header"%>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-8 mx-auto form-wrap alert alert-dark pb-5">
+        <div class='font-wight-bold h1 py-3 text-center'>
           ユーザー情報変更
         </div>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+          <%= render partial: "shared/registration_update_form", locals: { f: f } %>
+          <div class='register-btn mt-4'>
+            <%= button_tag type: 'submit', class: "btn btn-block btn-outline-primary" do %>
+              情報変更<i class="fas fa-user-cog mx-1 mx-1"></i>
+            <% end %>
+          </div>
+        <% end %>
       </div>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-        <%= render partial: "shared/registration_update_form", locals: { f: f } %>
-        <div class='register-btn mt-4'>
-          <%= button_tag type: 'submit', class: "btn btn-block btn-outline-primary" do %>
-            情報変更<i class="fas fa-user-cog mx-1 mx-1"></i>
-          <% end %>
-        </div>
-      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/entrances/registrations.html.erb
+++ b/app/views/entrances/registrations.html.erb
@@ -3,17 +3,13 @@
   <div class="font-weight-bold h1 m-3 text-center">新規登録</div>
   <div class="h2 m-3 text-center">アカウントの種類を<br class='d-block d-sm-none'>選んでください</div>
   <div class="row justify-content-around">
-    <%= link_to  new_user_registration_path, class:"text-reset " do%>
-      <div class="alert alert-primary text-center py-5 btn">
-        <div class="h1">見るだけ<i class="fas fa-user h3 mx-3"></i></div>
-        <div class="h5">一般ユーザー登録</div>
-      </div>
+    <%= link_to  new_user_registration_path, class:"col-md-4 h-auto alert alert-primary text-center py-5 btn" do%>
+      <div class="h1">見るだけ<i class="fas fa-user h3 mx-3"></i></div>
+      <div class="h5">一般ユーザー登録</div>
     <% end %>
-    <%= link_to  new_admin_registration_path, class:"text-reset" do%>
-      <div class="alert alert-dark text-center py-5 btn">
+    <%= link_to  new_admin_registration_path, class:"col-md-4 h-auto alert alert-dark text-center py-5 btn" do%>
         <div class="h1 ">出店する<i class="fas fa-store h3 mx-2"></i></div>
         <div class="h5">店舗ユーザー登録</div>
-      </div>
     <% end %>
   </div>
   <div class="text-right">

--- a/app/views/entrances/sessions.html.erb
+++ b/app/views/entrances/sessions.html.erb
@@ -3,15 +3,11 @@
   <div class="font-weight-bold h1 m-3 text-center">ログイン</div>
   <div class="h2 m-3 text-center">アカウントの種類を<br class='d-block d-sm-none'>選んでください</div>
   <div class="row justify-content-around">
-    <%= link_to  new_user_session_path, class:"text-reset" do%>
-      <div class="alert alert-primary text-center py-5 btn">
-        <div class="h1">一般ユーザー<i class="fas fa-user h3 mx-2"></i></div>
-      </div>
+    <%= link_to  new_user_session_path, class:"col-md-4 h-auto alert alert-primary text-center py-5 btn" do%>
+      <div class="h1">一般ユーザー<i class="fas fa-user h3 mx-2"></i></div>
     <% end %>
-    <%= link_to  new_admin_session_path, class:"text-reset" do%>
-      <div class="alert alert-dark text-center py-5 btn">
-        <div class="h1">店舗ユーザー<i class="fas fa-store h3 mx-2"></i></div>
-      </div>
+    <%= link_to  new_admin_session_path, class:"col-md-4 h-auto alert alert-dark text-center py-5 btn" do%>
+      <div class="h1">店舗ユーザー<i class="fas fa-store h3 mx-2"></i></div>
     <% end %>
   </div>
   <div class="text-right">

--- a/app/views/entrances/user_chanege_desroy.html.erb
+++ b/app/views/entrances/user_chanege_desroy.html.erb
@@ -1,20 +1,5 @@
 <%= render "shared/header"%>
 <div class="container my-3">
-  <div class="font-weight-bold h1 m-3 text-center">登録変更</div>
-  <div class="h2 m-3 text-center">アカウントに行う処理を選んでください</div>
-  <div class="row justify-content-around p-5 mb-5">
-    <div class="col-md-4 h-auto alert alert-info text-center py-5 btn">
-      <%= link_to  edit_user_registration_path, class:"text-reset" do%>
-        <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
-        <div class="h5">ユーザー情報変更</div>
-      <% end %>
-    </div>
-    <div class="col-md-4 h-auto alert alert-danger text-center py-5 btn">
-      <%= link_to  user_registration_path, method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class:"text-reset" do%>
-        <div class="h1 ">削除する<i class="fas fa-user-slash h3 mx-2"></i></div>
-        <div class="h5">ユーザー情報削除</div>
-      <% end %>
-    </div>
-  </div>
+  <%= render partial: "shared/user_chanege_desroy" %>
 </div>
 <%= render "shared/second-footer"%>

--- a/app/views/shared/_registration_update_form.html.erb
+++ b/app/views/shared/_registration_update_form.html.erb
@@ -1,9 +1,9 @@
 <%= render "devise/shared/error_messages", resource: resource %>
 <div class = 'form-group'>
-  <div class='form-text-wrap'><%= f.label :name, "ユーザー名" %></div>
+  <div class='form-text-wrap'><%= f.label :name, "アカウント名" %><i class="fas fa-user mx-1"></i></div>
   <%= f.text_field :name, autofocus: true, class: "form-control", placeholder: "最大10文字", maxlength: 10 %>
 </div>
 <div class = 'form-group'>
-  <div class='form-text-wrap'><%= f.label :email, "メールアドレス" %></div>
+  <div class='form-text-wrap'><%= f.label :email, "メールアドレス" %><i class="far fa-envelope mx-1"></i></div>
   <%= f.email_field :email, autocomplete: "email", class: "form-control", placeholder: "xxx@email.com" %>
 </div>

--- a/app/views/shared/_user_chanege_desroy.html.erb
+++ b/app/views/shared/_user_chanege_desroy.html.erb
@@ -1,12 +1,26 @@
 <div class="font-weight-bold h1 m-3 text-center">登録変更</div>
 <div class="h2 m-3 text-center">アカウントに行う処理を選んでください</div>
 <div class="row justify-content-around p-5 mb-5">
+  <% if user_signed_in? %>
+    <%= link_to  edit_user_registration_path, class:"col-md-4 h-auto  btn alert alert-info py-5 text-center" do %>
+    <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
+    <div class="h5">ユーザー情報変更</div>
+    <% end %>
+
+    <%= link_to  user_registration_path, method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class:"col-md-4 h-auto btn alert alert-danger py-5 text-center " do%>
+    <div class="h1 ">削除する<i class="fas fa-user-slash h3"></i></div>
+    <div class="h5">ユーザー情報削除</div>
+    <% end %>
+
+  <% elsif admin_signed_in? %>
     <%= link_to  edit_admin_registration_path, class:"col-md-4 h-auto  btn alert alert-info py-5 text-center" do %>
-      <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
-      <div class="h5">ユーザー情報変更</div>
+    <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
+    <div class="h5">ユーザー情報変更</div>
     <% end %>
+
     <%= link_to  admin_registration_path, method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class:"col-md-4 h-auto btn alert alert-danger py-5 text-center " do%>
-      <div class="h1 ">削除する<i class="fas fa-user-slash h3"></i></div>
-      <div class="h5">ユーザー情報削除</div>
+    <div class="h1 ">削除する<i class="fas fa-user-slash h3"></i></div>
+    <div class="h5">ユーザー情報削除</div>
     <% end %>
+  <% end %>
 </div>

--- a/app/views/shared/_user_chanege_desroy.html.erb
+++ b/app/views/shared/_user_chanege_desroy.html.erb
@@ -1,0 +1,12 @@
+<div class="font-weight-bold h1 m-3 text-center">登録変更</div>
+<div class="h2 m-3 text-center">アカウントに行う処理を選んでください</div>
+<div class="row justify-content-around p-5 mb-5">
+    <%= link_to  edit_admin_registration_path, class:"col-md-4 h-auto  btn alert alert-info py-5 text-center" do %>
+      <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
+      <div class="h5">ユーザー情報変更</div>
+    <% end %>
+    <%= link_to  admin_registration_path, method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class:"col-md-4 h-auto btn alert alert-danger py-5 text-center " do%>
+      <div class="h1 ">削除する<i class="fas fa-user-slash h3"></i></div>
+      <div class="h5">ユーザー情報削除</div>
+    <% end %>
+</div>

--- a/app/views/shared/_user_chanege_desroy.html.erb
+++ b/app/views/shared/_user_chanege_desroy.html.erb
@@ -1,6 +1,6 @@
 <div class="font-weight-bold h1 m-3 text-center">登録変更</div>
 <div class="h2 m-3 text-center">アカウントに行う処理を選んでください</div>
-<div class="row justify-content-around p-5 mb-5">
+<div class="row justify-content-around p-5">
   <% if user_signed_in? %>
     <%= link_to  edit_user_registration_path, class:"col-md-4 h-auto  btn alert alert-info py-5 text-center" do %>
     <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>

--- a/app/views/shops/my.html.erb
+++ b/app/views/shops/my.html.erb
@@ -1,22 +1,6 @@
 <%= render "shared/header"%>
 <div class="container my-3">
-  <div class="font-weight-bold h1 m-3 text-center">登録変更</div>
-  <div class="h2 m-3 text-center">アカウントに行う処理を選んでください</div>
-  <div class="row justify-content-around p-5 mb-5">
-    <div class="col-md-4 h-auto alert alert-info text-center py-5 btn">
-      <%= link_to  edit_admin_registration_path, class:"text-reset" do%>
-        <div class="h1">変更する<i class="fas fa-user-cog h3 mx-2"></i></div>
-        <div class="h5">ユーザー情報変更</div>
-      <% end %>
-    </div>
-    <div class="col-md-4 h-auto alert alert-danger text-center py-5 btn">
-      <%= link_to  admin_registration_path, method: :delete, data: { confirm: "この作業は戻せません。本当に削除しますか?" }, class:"text-reset" do%>
-        <div class="h1 ">削除する<i class="fas fa-user-slash h3 mx-2"></i></div>
-        <div class="h5">ユーザー情報削除</div>
-      <% end %>
-    </div>
-  </div>
-
+  <%= render partial: "shared/user_chanege_desroy" %>
   <div class="font-weight-bold h2"><%= "#{current_admin.name}さんの店舗一覧 全#{@shop_count}店" %></div>
   <div class="row">
     <%= render partial: "shop" ,collection:  @shops%>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,19 +1,19 @@
-<%= render "shared/second-header"%>
-  <div class="registration-main">
-    <div class="form-wrap alert-primary">
-      <div class='form-header'>
-        <div class='font-wight-bold h1 py-3'>
+<%= render "shared/header"%>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-8 mx-auto form-wrap alert alert-primary pb-5">
+        <div class='font-wight-bold h1 py-3 text-center'>
           ユーザー情報変更
         </div>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+          <%= render partial: "shared/registration_update_form", locals: { f: f } %>
+          <div class='register-btn mt-4'>
+            <%= button_tag type: 'submit', class: "btn btn-block btn-outline-primary" do %>
+              情報変更<i class="fas fa-user-cog mx-1 mx-1"></i>
+            <% end %>
+          </div>
+        <% end %>
       </div>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-        <%= render partial: "shared/registration_update_form", locals: { f: f } %>
-        <div class='register-btn mt-4'>
-          <%= button_tag type: 'submit', class: "btn btn-block btn-outline-primary" do %>
-            情報変更<i class="fas fa-user-cog mx-1 mx-1"></i>
-          <% end %>
-        </div>
-      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# What
- ログインアカウント選択ページ、登録アカウント選択ページ、登録情報選択ページのボタンの範囲を修正しました
- その他、ヘッダーと背景の細かい修正をしました
# Why
- ボタンの端がリンク範囲に含まれておらず、クリックミスの原因になると考えられたため

close #59 