### PR TITLE
N＋1問題対策 #66

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
+  gem 'bullet'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.2)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capistrano (3.14.1)
       airbrussh (>= 1.0.0)
@@ -386,6 +389,7 @@ GEM
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    uniform_notifier (1.13.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -415,6 +419,7 @@ DEPENDENCIES
   active_hash
   aws-sdk-s3
   bootsnap (>= 1.4.2)
+  bullet
   byebug
   capistrano
   capistrano-bundler

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth if Rails.env.production?
   # あとでONする
 
   before_action :configure_permitted_parameters, if: :devise_controller?

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -4,7 +4,7 @@ class FavoritesController < ApplicationController
 
   def index
     if user_signed_in?
-      @shops = current_user.favorite_shops.order('favorites.updated_at DESC').order(updated_at: 'DESC').page(params[:page]).per(PER)
+      @shops = current_user.favorite_shops.order('favorites.updated_at DESC').page(params[:page]).per(PER)
       @shop_count = current_user.favorite_shops.count
     elsif admin_signed_in?
       @shops = current_admin.favorite_shops.order('favorites.updated_at DESC').page(params[:page]).per(PER)

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -4,10 +4,10 @@ class FavoritesController < ApplicationController
 
   def index
     if user_signed_in?
-      @shops = current_user.favorite_shops.page(params[:page]).per(PER)
+      @shops = current_user.favorite_shops.order('favorites.updated_at DESC').order(updated_at: 'DESC').page(params[:page]).per(PER)
       @shop_count = current_user.favorite_shops.count
     elsif admin_signed_in?
-      @shops = current_admin.favorite_shops.page(params[:page]).per(PER)
+      @shops = current_admin.favorite_shops.order('favorites.updated_at DESC').page(params[:page]).per(PER)
       @shop_count = current_admin.favorite_shops.count
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,7 +29,7 @@ class ItemsController < ApplicationController
   end
 
   def search
-    @items = Item.search(params[:keyword]).order(count: 'DESC')
+    @items = Item.search(params[:keyword]).includes(:shop).order(count: 'DESC')
     @keyword = params[:keyword]
   end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -92,7 +92,7 @@
           <div style="display: none;", class="table table-sm table-striped", id="messages_table">
         <% end %>
           <div id="messages">
-            <%= render partial: "shared/message" ,collection: @shop.messages.order(updated_at: "DESC").limit(10)%>
+            <%= render partial: "shared/message" ,collection: @shop.messages.includes(:user, :admin).order(updated_at: "DESC").limit(10)%>
           </div>
         </div>
       <% else %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,14 @@
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  # Bullet.growl         = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -59,4 +69,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
 end


### PR DESCRIPTION
# What
- Bulletを導入した
- N＋1問題発生箇所について修正を行った
- お気に入り一覧のソート順をfavolitesテーブルのupdated_atの降順に設定した
# Why
- Bulletを入れることで効率的にN＋１問題を発見できるため
- N＋1問題発生箇所ではレスポンスの悪化が起こるため
- 最近お気に入りに入れたものから見たいと考えられるため
close #66 